### PR TITLE
Change how polygon tests get credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
             - libssl-dev
 
 script:
-    - make
+    - make -j 8
     - sudo make install
     - ./cp-tools -v
     - ./cp-run_tests

--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ $ ./cp-run_tests
 
 ### Polygon connection tests
 
-If you are using Travis on your own fork you must add the environment variables `POLYGON_KEY` and `POLYGON_SECRET` following the [official tutorial](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
+On a local run of the tests you need to set both environment variables: `POLYGON_KEY` and `POLYGON_SECRET`.
 
-On a local run it will prioritize the environment variables described above, but having valid credentials in your `~/.cp-tools-config.json` will work also.
+If you are using Travis on your own fork you must add the environment variables `POLYGON_KEY` and `POLYGON_SECRET` following the [official tutorial](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).
 
 ## Technologies
 

--- a/tests/polygon.cpp
+++ b/tests/polygon.cpp
@@ -17,7 +17,8 @@ SCENARIO("Command polygon", "[polygon]") {
 
     GIVEN("An execution of the command") {
         std::filesystem::remove(user_config_path + ".bkp");
-        std::filesystem::copy_file(user_config_path, user_config_path + ".bkp");
+        if(std::filesystem::exists(user_config_path))
+            std::filesystem::copy_file(user_config_path, user_config_path + ".bkp");
 
         WHEN("There is no options") {
             AND_WHEN("There's no credentials file in user's home") {
@@ -123,7 +124,8 @@ SCENARIO("Command polygon", "[polygon]") {
         }
 
         std::filesystem::remove(user_config_path);
-        std::filesystem::copy_file(user_config_path + ".bkp", user_config_path);
+        if(std::filesystem::exists(user_config_path + ".bkp"))
+            std::filesystem::copy_file(user_config_path + ".bkp", user_config_path);
         std::filesystem::remove(user_config_path + ".bkp");
     }
 }

--- a/tests/polygon.cpp
+++ b/tests/polygon.cpp
@@ -1,5 +1,4 @@
 #include <filesystem>
-#include <fstream>
 #include <getopt.h>
 #include <string>
 
@@ -11,20 +10,19 @@
 
 using cptools::commands::polygon::run;
 
-const std::filesystem::path config_path = cptools::fs::get_default_config_path();
-const std::filesystem::path config_bkp = config_path.generic_string() + ".bkp";
 const std::string default_json_invalid{"{\"polygon\":{\"key\": \"\", \"secret\": \"\"}}"};
+const std::string user_config_path = cptools::fs::get_default_config_path();
 
 SCENARIO("Command polygon", "[polygon]") {
-    auto config_path_exists = cptools::fs::exists(config_path).ok;
-    auto config_bkp_exists = cptools::fs::exists(config_bkp).ok;
-    if (not config_bkp_exists and config_path_exists)
-        copy_file(config_path, config_bkp);
 
     GIVEN("An execution of the command") {
+        std::filesystem::remove(user_config_path + ".bkp");
+        std::filesystem::copy_file(user_config_path, user_config_path + ".bkp");
+
         WHEN("There is no options") {
             AND_WHEN("There's no credentials file in user's home") {
-                std::filesystem::remove(config_path);
+                std::filesystem::remove(user_config_path);
+
                 int argc = 2;
                 char *const argv[]{(char *)"cp-tools", (char *)"polygon"};
                 optind = 1;
@@ -37,10 +35,7 @@ SCENARIO("Command polygon", "[polygon]") {
             }
 
             AND_WHEN("There's an invalid credentials file in user's home") {
-                std::filesystem::remove(config_path);
-                std::ofstream config_stream{config_path};
-                config_stream << default_json_invalid;
-                config_stream.close();
+                cptools::fs::overwrite_file(user_config_path, default_json_invalid);
 
                 int argc = 2;
                 char *const argv[]{(char *)"cp-tools", (char *)"polygon"};
@@ -84,32 +79,20 @@ SCENARIO("Command polygon", "[polygon]") {
         }
 
         WHEN("There are valid credentials") {
-            // Load valid credentials giving priotity to environtment variables
-            auto polygon_key_env = getenv("POLYGON_KEY");
-            auto polygon_secret_env = getenv("POLYGON_SECRET");
-            bool use_env = polygon_key_env && polygon_secret_env;
+            const auto env_key = getenv("POLYGON_KEY");
+            const auto env_secret = getenv("POLYGON_SECRET");
 
-            std::string polygon_key, polygon_secret;
-            if (not use_env) {
-                auto config = cptools::util::read_json_file(config_bkp);
-                polygon_key = cptools::util::get_json_value<std::string>(config, "polygon|key", "");
-                polygon_secret =
-                    cptools::util::get_json_value<std::string>(config, "polygon|secret", "");
-            } else {
-                polygon_key = std::string(polygon_key_env);
-                polygon_secret = std::string(polygon_secret_env);
-            }
+            REQUIRE(env_key != NULL);
+            REQUIRE(env_secret != NULL);
+
+            const std::string polygon_key(env_key);
+            const std::string polygon_secret(env_secret);
 
             AND_WHEN("They are in a valid credentials file in user's home") {
-                // Insert credentials in the valid json config file
                 auto valid_json = "{\"polygon\":{\"key\":\"" + polygon_key + "\",\"secret\":\"" +
                                   polygon_secret + "\"}}";
 
-                if (cptools::fs::exists(config_path).ok)
-                    std::filesystem::remove(config_path);
-                std::ofstream valid_config(config_path);
-                valid_config << valid_json;
-                valid_config.close();
+                cptools::fs::overwrite_file(user_config_path, valid_json);
 
                 THEN("The output must be a connection successful message") {
                     int argc = 2;
@@ -138,11 +121,9 @@ SCENARIO("Command polygon", "[polygon]") {
                 }
             }
         }
-    }
 
-    if (cptools::fs::exists(config_bkp).ok) {
-        std::filesystem::remove(config_path);
-        std::filesystem::copy_file(config_bkp, config_path);
-        std::filesystem::remove(config_bkp);
+        std::filesystem::remove(user_config_path);
+        std::filesystem::copy_file(user_config_path + ".bkp", user_config_path);
+        std::filesystem::remove(user_config_path + ".bkp");
     }
 }


### PR DESCRIPTION
The tests were giving priority to environment variables, if they didn't
exist then it would use the default user config json file. Now this file
will never be used during tests.